### PR TITLE
Add shebang line

### DIFF
--- a/composer-autocomplete
+++ b/composer-autocomplete
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function _composer_scripts() {
     local cur prev;
     _get_comp_words_by_ref -n : cur


### PR DESCRIPTION
The main reason to use [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) is syntax highlighting