### PR TITLE
Complete arguments along with scripts for run-script.

### DIFF
--- a/composer-autocomplete
+++ b/composer-autocomplete
@@ -16,20 +16,15 @@ function _composer_scripts() {
     done
 
     #
-    # Complete scripts for composer "run-script" command.
-    #
-    if [ "$subcmd" == "run-script" ] ; then
-        local scripts=$("$cmd" --no-ansi 2> /dev/null | grep 'script as defined in composer.json' | awk '/^ +[a-z]+/ { print $1 }')
-        COMPREPLY=( $(compgen -W "${scripts}" -- ${cur}) )
-        return 0
-    fi
-
-    #
     # Complete the arguments to some of the commands.
     #
     if [ "$subcmd" != "${COMP_WORDS[0]}" ] ; then
         local opts=$("$cmd" "$subcmd" -h --no-ansi 2> /dev/null | tr -cs '[=-=][:alpha:]_' '[\n*]' | grep '^-')
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        # Complete scripts for composer "run-script" command.
+        if [ "$subcmd" == "run-script" ] ; then
+            local scripts=$("$cmd" --no-ansi 2> /dev/null | grep 'script as defined in composer.json' | awk '/^ +[a-z]+/ { print $1 }')
+        fi
+        COMPREPLY=( $(compgen -W "${opts} ${scripts}" -- ${cur}) )
         return 0
     fi
 


### PR DESCRIPTION
This PR adds the completion of arguments of the `run-script` subcommand alongside the scripts from the `composer.json`.