### PR TITLE
[FIX] Fixes issue with hirak/prestissimo

### DIFF
--- a/composer-autocomplete
+++ b/composer-autocomplete
@@ -19,7 +19,7 @@ function _composer_scripts() {
     # Complete the arguments to some of the commands.
     #
     if [ "$subcmd" != "${COMP_WORDS[0]}" ] ; then
-        local opts=$("$cmd" "$subcmd" -h --no-ansi 2> /dev/null | tr -cs '[=-=][:alpha:]_' '[\n*]' | grep '^-')
+        local opts=$("$cmd" help "$subcmd" --no-ansi 2> /dev/null | tr -cs '[=-=][:alpha:]_' '[\n*]' | grep '^-')
         case "$subcmd" in
             "run-script")
                 # Complete scripts for composer "run-script" command.


### PR DESCRIPTION
Trying to get options for `update` subcommand can result in a long
waiting period and seemingly unresponsive bash completion when
composer plugin 'hirak/prestissimo' is being used.
The latter will prefetch repositories whenever encountering the
subcommands `install`, `update` and the likes. When a project uses many
dependencies and repositories, this can take a while. An issue has also
been filed with prestissimo plugin (see https://github.com/hirak/prestissimo/issues/225)
yet using the `help [command]` subcommand in favor to `[command] -h`
in order to retrieve all available options seems more reliable anyway.